### PR TITLE
fix : createAPI에서 error throw 코드 삭제

### DIFF
--- a/utils/api.tsx
+++ b/utils/api.tsx
@@ -33,11 +33,6 @@ const createAPI = async (
     ...restOptions,
   });
 
-  if (!res.ok) {
-    const error = new Error("API Error");
-    throw error;
-  }
-
   return res;
 };
 


### PR DESCRIPTION
# 🔍 PR 개요

createAPI에서 error throw 하는 거 삭제

## 📝 작업 내용

createAPI에서 error를 throw 하던 것을 삭제했습니다

- [ ] createAPI에서 error throw 코드 삭제

## 🔗 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->

- Closes #이슈번호
- Related to #이슈번호

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

### Before

<!-- 변경 전 스크린샷 -->

### After

<!-- 변경 후 스크린샷 -->

## 🧪 체크리스트

<!-- 테스트 항목을 체크해주세요 -->

- [x] 수동 테스트 완료
- [x] 불필요한 코드 없음 (console.log, 주석 등)
- [x] 명확한 커밋 메세지
- [x] 충분한 문서화

## 🔄 변경 로직 설명

createAPI에서 res.ok가 아닌 경우 무조건 error를 던지는데, 그럴 경우 api를 사용하는 함수에서는 res.status에 따른 오류 메시지 설정이 불가능해지고 무조건 catch문에 잡혀 '네트워크 오류' 메시지를 던지게 됩니다. 

따라서 createAPI에서는 그냥 res를 리턴하게 만들어, 오류처리는  api를 사용하는 함수에서 처리하도록 바꾸었습니다

```js
// 예시 코드나 설명
```
